### PR TITLE
Create multilingual tool landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
-# gotoolslab
+# GoTools Lab
+
+GoTools Lab is a multilingual collection of lightweight browser tools inspired by platforms such as 123apps.com. The site showcases grouped utilities for audio, video, document, and productivity workflows together with a live rich-text editor that works entirely in the browser.
+
+## Features
+
+- **Clear categorisation** – Audio, video, document, and everyday utility sections with descriptive tool cards.
+- **Global-ready localisation** – Switch the entire interface between English, Simplified Chinese, and Spanish. The selection is stored so visitors return to their preferred language.
+- **Live editor** – Rich-text editor with formatting buttons, reusable templates, local auto-save, downloads, clipboard copy, and a persistent dark theme toggle.
+- **Search and discovery** – Instant filtering across tool cards to help visitors find the right app quickly.
+- **Privacy friendly** – All interactions happen client side; drafts are saved to local storage only when available.
+
+## Getting started
+
+The project is a static site and can be served with any HTTP server. One simple option is to use the built-in Python module:
+
+```bash
+python -m http.server 8000
+```
+
+Then visit [http://localhost:8000](http://localhost:8000) in your browser. The landing page, assets, and scripts are located at the repository root under `index.html` and `assets/`.
+
+## Project structure
+
+```
+.
+├── index.html        # Landing page
+├── assets/
+│   ├── css/
+│   │   └── main.css  # Styling
+│   └── js/
+│       └── main.js   # Behaviour, localisation, editor logic
+└── README.md
+```
+
+## Localization
+
+All translatable strings live in `assets/js/main.js` inside the `translations` object. Add or update language keys there to extend localisation support. Each new language should provide:
+
+- Navigation and hero strings
+- Category and tool descriptions
+- Editor UI copy, templates, and notifications
+- Footer and global reach messaging
+
+## Browser support
+
+The interface relies on modern browser features such as `flex`, `grid`, and the Clipboard API. When the Clipboard or Local Storage APIs are unavailable, the app gracefully falls back while keeping the core experience functional.

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,0 +1,537 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f5f7fb;
+  --bg-dark: #10131c;
+  --surface: #ffffff;
+  --surface-dark: #161b26;
+  --primary: #4d5cfa;
+  --primary-dark: #8792ff;
+  --text: #111827;
+  --text-muted: #4b5563;
+  --border: rgba(15, 23, 42, 0.08);
+  --radius: 16px;
+  font-size: 16px;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+body.dark {
+  background: var(--bg-dark);
+  color: #e2e8f0;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.top-bar {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(18px);
+  padding: 1rem 3vw;
+  border-bottom: 1px solid var(--border);
+  z-index: 100;
+}
+
+body.dark .top-bar {
+  background: rgba(15, 18, 28, 0.85);
+  border-color: rgba(148, 163, 184, 0.2);
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.25rem;
+  letter-spacing: 0.04em;
+}
+
+.main-nav {
+  display: flex;
+  gap: 1rem;
+  font-weight: 500;
+}
+
+.main-nav a {
+  padding: 0.4rem 0.6rem;
+  border-radius: 999px;
+  transition: background 0.2s ease;
+}
+
+.main-nav a:hover,
+.main-nav a:focus {
+  background: rgba(77, 92, 250, 0.12);
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.language-switch {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.language-switch select {
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: transparent;
+  font: inherit;
+}
+
+body.dark .language-switch select {
+  border-color: rgba(148, 163, 184, 0.3);
+  color: inherit;
+}
+
+.cta {
+  padding: 0.55rem 1.25rem;
+  border-radius: 999px;
+  border: none;
+  background: var(--primary);
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(77, 92, 250, 0.3);
+}
+
+main {
+  padding: 0 3vw 6rem;
+}
+
+.hero {
+  margin-top: 3rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+  align-items: center;
+}
+
+.hero h1 {
+  font-size: clamp(2.5rem, 4vw, 3.25rem);
+  margin-bottom: 1rem;
+}
+
+.hero-subtitle {
+  color: var(--text-muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+  max-width: 560px;
+}
+
+.hero-actions {
+  margin-top: 2rem;
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.hero-actions .primary,
+.hero-actions .secondary {
+  padding: 0.8rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.hero-actions .primary {
+  background: var(--primary);
+  color: #fff;
+}
+
+.hero-actions .secondary {
+  background: rgba(77, 92, 250, 0.12);
+  color: var(--primary);
+}
+
+.hero-showcase {
+  display: grid;
+  gap: 1rem;
+}
+
+.showcase-card {
+  padding: 1.25rem;
+  background: var(--surface);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
+}
+
+body.dark .showcase-card,
+body.dark .category-card,
+body.dark .tool-card,
+body.dark .highlight-card,
+body.dark .editor-panel,
+body.dark .reach-card,
+body.dark .search-inner {
+  background: var(--surface-dark);
+  border-color: rgba(148, 163, 184, 0.2);
+  box-shadow: none;
+}
+
+.search {
+  margin: 4rem 0 2rem;
+}
+
+.search-inner {
+  background: var(--surface);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+#search-input {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  font: inherit;
+}
+
+body.dark #search-input {
+  background: rgba(148, 163, 184, 0.08);
+  border-color: rgba(148, 163, 184, 0.25);
+  color: #f8fafc;
+}
+
+.search-meta {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.section-header {
+  max-width: 640px;
+  margin-bottom: 2rem;
+}
+
+.section-header h2 {
+  font-size: 2rem;
+  margin-bottom: 0.75rem;
+}
+
+.section-header p {
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.category-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.category-card {
+  background: var(--surface);
+  padding: 1.6rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: transform 0.2s ease;
+}
+
+.category-card:hover {
+  transform: translateY(-4px);
+}
+
+.category-icon {
+  font-size: 1.8rem;
+}
+
+.tool-list {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.tool-card {
+  display: block;
+  padding: 0.9rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(77, 92, 250, 0.15);
+  background: rgba(77, 92, 250, 0.08);
+  transition: border 0.2s ease, transform 0.2s ease;
+}
+
+.tool-card.is-hidden {
+  display: none;
+}
+
+.tool-card:hover {
+  transform: translateX(4px);
+  border-color: rgba(77, 92, 250, 0.4);
+}
+
+.tool-card h4 {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+}
+
+.tool-card p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.highlights {
+  margin: 4.5rem 0;
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.highlight-card {
+  background: var(--surface);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  padding: 1.4rem;
+}
+
+.editor {
+  margin: 4.5rem 0;
+}
+
+.editor-panel {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(200px, 240px) minmax(280px, 1fr);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+}
+
+.editor-sidebar ul {
+  padding: 0;
+  margin: 1rem 0;
+  list-style: none;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.editor-sidebar button {
+  width: 100%;
+  padding: 0.6rem 0.8rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: transparent;
+  font: inherit;
+  cursor: pointer;
+}
+
+.editor-sidebar button:hover,
+.editor-sidebar button:focus {
+  border-color: var(--primary);
+}
+
+body.dark .editor-sidebar button {
+  border-color: rgba(148, 163, 184, 0.2);
+  color: inherit;
+}
+
+.editor-status {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #10b981;
+  box-shadow: 0 0 0 6px rgba(16, 185, 129, 0.18);
+}
+
+.editor-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+}
+
+.editor-toolbar button {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: transparent;
+  font: 600 1rem/1 'Inter';
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.editor-toolbar button:hover,
+.editor-toolbar button:focus {
+  background: rgba(77, 92, 250, 0.12);
+}
+
+body.dark .editor-toolbar button {
+  border-color: rgba(148, 163, 184, 0.25);
+  color: inherit;
+}
+
+body.dark .editor-toolbar button:hover,
+body.dark .editor-toolbar button:focus {
+  background: rgba(125, 138, 255, 0.16);
+}
+
+.editor-canvas {
+  min-height: 280px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  padding: 1.2rem;
+  background: rgba(148, 163, 184, 0.08);
+  overflow-y: auto;
+  line-height: 1.6;
+}
+
+.editor-canvas:focus {
+  outline: 2px solid var(--primary);
+}
+
+.global-reach {
+  margin-bottom: 5rem;
+}
+
+.reach-grid {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.reach-card {
+  background: var(--surface);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  padding: 1.4rem;
+}
+
+.toast {
+  position: fixed;
+  left: 50%;
+  bottom: 2rem;
+  transform: translateX(-50%) translateY(20px);
+  background: rgba(15, 23, 42, 0.92);
+  color: #f8fafc;
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  z-index: 200;
+}
+
+.dark .toast {
+  background: rgba(148, 163, 184, 0.95);
+  color: #0f172a;
+}
+
+.toast.is-visible {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+.site-footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 2rem 3vw 3rem;
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+.footer-links {
+  display: flex;
+  gap: 1rem;
+}
+
+.footer-links a {
+  color: inherit;
+}
+
+.footer-meta {
+  flex-basis: 100%;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+body.dark .editor-canvas {
+  background: rgba(148, 163, 184, 0.08);
+}
+
+body.dark .hero-subtitle,
+body.dark .section-header p,
+body.dark .tool-card p,
+body.dark .search-meta,
+body.dark .editor-status,
+body.dark .reach-card p {
+  color: rgba(226, 232, 240, 0.8);
+}
+
+@media (max-width: 720px) {
+  .top-bar {
+    flex-wrap: wrap;
+    padding: 0.75rem 5vw;
+  }
+
+  .main-nav {
+    order: 3;
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .editor-panel {
+    grid-template-columns: 1fr;
+  }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,794 @@
+const translations = {
+  en: {
+    branding: {
+      title: 'GoTools Lab',
+    },
+    navigation: {
+      allTools: 'All tools',
+      categories: 'Categories',
+      editor: 'Online editor',
+      support: 'Support',
+      languageLabel: 'Language',
+      cta: 'Start now',
+    },
+    hero: {
+      kicker: 'One toolkit for every creator',
+      title: 'Powerful online tools with crystal-clear categories',
+      subtitle:
+        'Tackle media, documents, and everyday tasks in seconds. Switch the entire experience to your preferred language and stay productive anywhere.',
+      primary: 'Try the online editor',
+      secondary: 'Explore categories',
+    },
+    showcase: {
+      media: {
+        title: 'Media conversion',
+        body: 'Compress, convert, and trim audio or video files right in your browser.',
+      },
+      documents: {
+        title: 'Smart documents',
+        body: 'Merge, sign, or transform PDFs without uploading sensitive data.',
+      },
+      utilities: {
+        title: 'Quick utilities',
+        body: 'From screen recorders to GIF makers, launch a tool in one click.',
+      },
+    },
+    search: {
+      label: 'Search tools',
+      placeholder: 'Search for a tool…',
+      meta: '48 tools & growing — filter by typing',
+    },
+    categories: {
+      title: 'Curated categories',
+      subtitle:
+        'Jump straight into the toolkit you need. Every category bundles focused tools with consistent interfaces.',
+    },
+    category: {
+      audio: {
+        title: 'Audio studio',
+        description: 'Trim, mix, and convert audio formats without leaving your browser.',
+      },
+      video: {
+        title: 'Video lab',
+        description: 'Edit, resize, and compress videos with lightning-fast previews.',
+      },
+      document: {
+        title: 'Document hub',
+        description: 'Securely transform PDFs, Office files, and scans across formats.',
+      },
+      utility: {
+        title: 'Everyday utilities',
+        description: 'Lightweight helpers for screenshots, archives, and productivity.',
+      },
+    },
+    tool: {
+      audioTrimmer: {
+        title: 'Audio trimmer',
+        description: 'Cut MP3 or WAV clips precisely online.',
+      },
+      audioConverter: {
+        title: 'Audio converter',
+        description: 'Switch between MP3, WAV, FLAC, and more instantly.',
+      },
+      noiseReducer: {
+        title: 'Noise reducer',
+        description: 'Clean background noise with AI-powered smoothing.',
+      },
+      videoCutter: {
+        title: 'Video cutter',
+        description: 'Split videos into scenes in seconds.',
+      },
+      videoCompressor: {
+        title: 'Video compressor',
+        description: 'Reduce file sizes without losing HD clarity.',
+      },
+      subtitleMaker: {
+        title: 'Subtitle maker',
+        description: 'Generate subtitles with live translations.',
+      },
+      pdfMerge: {
+        title: 'PDF merger',
+        description: 'Combine multiple PDFs into a single file.',
+      },
+      pdfSigner: {
+        title: 'PDF signer',
+        description: 'Add signatures with legally binding timestamps.',
+      },
+      ocrReader: {
+        title: 'OCR reader',
+        description: 'Extract text from scans in 120+ languages.',
+      },
+      screenRecorder: {
+        title: 'Screen recorder',
+        description: 'Capture your screen with microphone audio.',
+      },
+      gifMaker: {
+        title: 'GIF maker',
+        description: 'Create looping GIFs from any video clip.',
+      },
+      archiveManager: {
+        title: 'Archive manager',
+        description: 'Zip and unzip archives with drag-and-drop convenience.',
+      },
+    },
+    highlights: {
+      privacy: {
+        title: 'Privacy-first workflow',
+        body: 'Your files stay in your browser. Processing happens locally whenever possible for maximum security.',
+      },
+      speed: {
+        title: 'Optimised for speed',
+        body: 'Global CDNs and GPU acceleration mean every tool is ready instantly no matter where you are.',
+      },
+      accessibility: {
+        title: 'Inclusive design',
+        body: 'Keyboard shortcuts, dark theme, and localisation support create a universal experience.',
+      },
+    },
+    editor: {
+      title: 'Live online editor',
+      subtitle:
+        'Format documents, collaborate in real time, and export text instantly. All changes happen in your browser with auto-save support.',
+      welcomeTitle: 'Welcome to the GoTools Lab editor',
+      welcomeBody:
+        'Use the toolbar to style text, load ready-made templates, or export your document without installing extra apps.',
+      templatesTitle: 'Quick templates',
+      templates: {
+        meeting: 'Meeting notes',
+        content: 'Content brief',
+        todo: 'Action plan',
+      },
+      status: 'Changes saved locally',
+      toolbar: {
+        bold: 'Bold',
+        italic: 'Italic',
+        underline: 'Underline',
+        bullet: 'Bulleted list',
+        numbered: 'Numbered list',
+        clear: 'Clear formatting',
+        download: 'Download as TXT',
+        copy: 'Copy to clipboard',
+        theme: 'Toggle dark theme',
+      },
+    },
+    global: {
+      title: 'Made for a global audience',
+      subtitle:
+        'We partner with creators and teams from 120+ countries. Switch between languages in one click and keep the same intuitive layout.',
+      localization: {
+        title: 'Adaptive localisation',
+        body: 'Interface strings, tooltips, and help guides follow your preferred language.',
+      },
+      support: {
+        title: '24/7 support',
+        body: 'Dedicated help centres in Asia, Europe, and the Americas for true local time zones.',
+      },
+      integrations: {
+        title: 'Team integrations',
+        body: 'Connect with Google Drive, Dropbox, and Slack to share work instantly.',
+      },
+    },
+    footer: {
+      tagline: 'Your everyday creative lab in the cloud.',
+      privacy: 'Privacy',
+      terms: 'Terms',
+      contact: 'Contact',
+      copyright: '© 2024 GoTools Lab. All rights reserved.',
+    },
+    editorTemplates: {
+      meeting:
+        '# Meeting notes\n\n**Date:**\n**Attendees:**\n\n## Agenda\n- \n- \n\n## Decisions\n- \n\n## Action items\n- Owner – Due date',
+      content:
+        '# Content brief\n\n**Campaign:**\n**Audience:**\n\n## Key message\n\n## Format\n- Article\n- Video\n- Social\n\n## Distribution\n- Website\n- Email\n- Ads',
+      todo:
+        '# Action plan\n\n1. \n2. \n3. \n\n**Next review:**',
+    },
+    notifications: {
+      copied: 'Copied to clipboard',
+      saved: 'Draft saved',
+      downloaded: 'File downloaded',
+    },
+  },
+  zh: {
+    branding: { title: 'GoTools 实验室' },
+    navigation: {
+      allTools: '所有工具',
+      categories: '工具分类',
+      editor: '在线编辑器',
+      support: '支持服务',
+      languageLabel: '语言',
+      cta: '立即使用',
+    },
+    hero: {
+      kicker: '面向创作者的一站式工具箱',
+      title: '强大在线工具，分类一目了然',
+      subtitle: '几秒钟完成媒体、文档与日常任务。随时切换整站语言，在任何地方保持高效。',
+      primary: '体验在线编辑器',
+      secondary: '浏览工具分类',
+    },
+    showcase: {
+      media: {
+        title: '媒体处理',
+        body: '直接在浏览器中压缩、转换、剪辑音视频文件。',
+      },
+      documents: {
+        title: '智能文档',
+        body: '合并、签署或转换 PDF，无需上传敏感数据。',
+      },
+      utilities: {
+        title: '实用工具',
+        body: '从屏幕录制到 GIF 制作，一键启动。',
+      },
+    },
+    search: {
+      label: '搜索工具',
+      placeholder: '搜索需要的工具…',
+      meta: '已上线 48 款工具，输入即筛选',
+    },
+    categories: {
+      title: '精选分类',
+      subtitle: '快速找到你需要的功能。每个分类都提供统一的使用体验。',
+    },
+    category: {
+      audio: {
+        title: '音频工坊',
+        description: '剪辑、混音、格式转换统统在线完成。',
+      },
+      video: {
+        title: '视频实验室',
+        description: '极速剪辑、裁剪、压缩，实时预览。',
+      },
+      document: {
+        title: '文档中心',
+        description: '安全地处理 PDF、Office 文件与扫描件。',
+      },
+      utility: {
+        title: '效率工具集',
+        description: '截图、压缩、效率小工具，轻装上阵。',
+      },
+    },
+    tool: {
+      audioTrimmer: { title: '音频剪辑', description: '精准裁剪 MP3/WAV 音频片段。' },
+      audioConverter: { title: '音频转换', description: '在 MP3、WAV、FLAC 等格式间快速切换。' },
+      noiseReducer: { title: '降噪助手', description: '利用智能算法消除背景噪声。' },
+      videoCutter: { title: '视频剪辑', description: '秒级分割视频片段。' },
+      videoCompressor: { title: '视频压缩', description: '显著减小体积，保持高清质量。' },
+      subtitleMaker: { title: '字幕生成', description: '实时生成字幕并支持翻译。' },
+      pdfMerge: { title: 'PDF 合并', description: '多份 PDF 一键合并。' },
+      pdfSigner: { title: 'PDF 签名', description: '快速添加电子签名并记录时间戳。' },
+      ocrReader: { title: 'OCR 识别', description: '识别 120+ 语言的扫描文字。' },
+      screenRecorder: { title: '屏幕录制', description: '连同麦克风声音一起录制屏幕。' },
+      gifMaker: { title: 'GIF 制作', description: '将视频片段转换为循环 GIF。' },
+      archiveManager: { title: '压缩包管理', description: '轻松拖拽完成打包与解压。' },
+    },
+    highlights: {
+      privacy: {
+        title: '隐私优先',
+        body: '文件保留在本地浏览器，尽可能在端侧完成处理。',
+      },
+      speed: {
+        title: '极速响应',
+        body: '全球 CDN 与 GPU 加速，让每个工具随时可用。',
+      },
+      accessibility: {
+        title: '通用设计',
+        body: '键盘快捷键、深色主题、多语言支持面向所有人。',
+      },
+    },
+    editor: {
+      title: '实时在线编辑器',
+      subtitle: '格式化文档、实时协作、即时导出，所有改动都在浏览器内完成并自动保存。',
+      welcomeTitle: '欢迎来到 GoTools 在线编辑器',
+      welcomeBody: '使用工具栏进行排版、调用现成模板或即时导出，无需安装任何软件。',
+      templatesTitle: '快速模板',
+      templates: {
+        meeting: '会议记录',
+        content: '内容策划',
+        todo: '执行清单',
+      },
+      status: '更改已本地保存',
+      toolbar: {
+        bold: '加粗',
+        italic: '斜体',
+        underline: '下划线',
+        bullet: '项目符号',
+        numbered: '编号列表',
+        clear: '清除格式',
+        download: '下载为 TXT',
+        copy: '复制内容',
+        theme: '切换深浅色',
+      },
+    },
+    global: {
+      title: '面向全球用户',
+      subtitle: '服务覆盖 120+ 国家/地区，一键切换语言，体验保持一致。',
+      localization: {
+        title: '智能本地化',
+        body: '界面文字、提示和帮助文档随语言变化自动调整。',
+      },
+      support: {
+        title: '7×24 支持',
+        body: '亚洲、欧洲、美洲均设有支持中心，跨时区无忧。',
+      },
+      integrations: {
+        title: '团队协同',
+        body: '与 Google Drive、Dropbox、Slack 无缝连接。',
+      },
+    },
+    footer: {
+      tagline: '云端的日常创作实验室。',
+      privacy: '隐私政策',
+      terms: '使用条款',
+      contact: '联系我们',
+      copyright: '© 2024 GoTools Lab. 版权所有。',
+    },
+    editorTemplates: {
+      meeting:
+        '# 会议记录\n\n**时间：**\n**参会人：**\n\n## 议程\n- \n- \n\n## 决议\n- \n\n## 待办事项\n- 负责人 – 截止日期',
+      content:
+        '# 内容策划\n\n**项目：**\n**目标人群：**\n\n## 核心信息\n\n## 内容形式\n- 文章\n- 视频\n- 社媒\n\n## 发布渠道\n- 网站\n- 邮件\n- 广告',
+      todo: '# 执行清单\n\n1. \n2. \n3. \n\n**下次跟进：**',
+    },
+    notifications: {
+      copied: '内容已复制',
+      saved: '草稿已保存',
+      downloaded: '文件已下载',
+    },
+  },
+  es: {
+    branding: { title: 'Laboratorio GoTools' },
+    navigation: {
+      allTools: 'Todas las herramientas',
+      categories: 'Categorías',
+      editor: 'Editor en línea',
+      support: 'Soporte',
+      languageLabel: 'Idioma',
+      cta: 'Empezar',
+    },
+    hero: {
+      kicker: 'Una caja de herramientas para cada creador',
+      title: 'Potentes utilidades en línea con categorías claras',
+      subtitle:
+        'Resuelve tareas de medios, documentos y productividad en segundos. Cambia todo el sitio a tu idioma preferido y mantente productivo donde estés.',
+      primary: 'Probar el editor en línea',
+      secondary: 'Explorar categorías',
+    },
+    showcase: {
+      media: {
+        title: 'Conversión multimedia',
+        body: 'Comprime, convierte y recorta audio o video directamente en el navegador.',
+      },
+      documents: {
+        title: 'Documentos inteligentes',
+        body: 'Combina, firma o transforma PDFs sin subir datos sensibles.',
+      },
+      utilities: {
+        title: 'Utilidades rápidas',
+        body: 'De grabadores de pantalla a creadores de GIF, abre una herramienta con un clic.',
+      },
+    },
+    search: {
+      label: 'Buscar herramientas',
+      placeholder: 'Busca una herramienta…',
+      meta: '48 herramientas y creciendo — escribe para filtrar',
+    },
+    categories: {
+      title: 'Categorías seleccionadas',
+      subtitle:
+        'Accede de inmediato al conjunto que necesitas. Cada categoría agrupa herramientas enfocadas con interfaces consistentes.',
+    },
+    category: {
+      audio: {
+        title: 'Estudio de audio',
+        description: 'Recorta, mezcla y convierte formatos de audio sin salir del navegador.',
+      },
+      video: {
+        title: 'Laboratorio de video',
+        description: 'Edita, redimensiona y comprime videos con vistas previas veloces.',
+      },
+      document: {
+        title: 'Centro de documentos',
+        description: 'Transforma de forma segura PDFs, archivos Office y escaneos.',
+      },
+      utility: {
+        title: 'Utilidades diarias',
+        description: 'Herramientas ligeras para capturas, archivos y productividad.',
+      },
+    },
+    tool: {
+      audioTrimmer: {
+        title: 'Recortador de audio',
+        description: 'Corta clips MP3 o WAV con precisión en línea.',
+      },
+      audioConverter: {
+        title: 'Convertidor de audio',
+        description: 'Cambia entre MP3, WAV, FLAC y más al instante.',
+      },
+      noiseReducer: {
+        title: 'Reductor de ruido',
+        description: 'Limpia el ruido de fondo con suavizado inteligente.',
+      },
+      videoCutter: {
+        title: 'Cortador de video',
+        description: 'Divide videos en escenas en segundos.',
+      },
+      videoCompressor: {
+        title: 'Compresor de video',
+        description: 'Reduce el tamaño sin perder claridad HD.',
+      },
+      subtitleMaker: {
+        title: 'Generador de subtítulos',
+        description: 'Genera subtítulos con traducciones en vivo.',
+      },
+      pdfMerge: {
+        title: 'Unir PDF',
+        description: 'Combina múltiples PDFs en un solo archivo.',
+      },
+      pdfSigner: {
+        title: 'Firmar PDF',
+        description: 'Añade firmas con sellos de tiempo válidos.',
+      },
+      ocrReader: {
+        title: 'Lector OCR',
+        description: 'Extrae texto de escaneos en más de 120 idiomas.',
+      },
+      screenRecorder: {
+        title: 'Grabador de pantalla',
+        description: 'Captura la pantalla con audio del micrófono.',
+      },
+      gifMaker: {
+        title: 'Creador de GIF',
+        description: 'Crea GIFs en bucle desde cualquier clip de video.',
+      },
+      archiveManager: {
+        title: 'Gestor de archivos',
+        description: 'Comprime y descomprime con arrastrar y soltar.',
+      },
+    },
+    highlights: {
+      privacy: {
+        title: 'Flujo centrado en la privacidad',
+        body: 'Tus archivos permanecen en el navegador. El procesamiento ocurre localmente cuando es posible.',
+      },
+      speed: {
+        title: 'Optimizado para velocidad',
+        body: 'CDNs globales y aceleración GPU mantienen todo listo al instante.',
+      },
+      accessibility: {
+        title: 'Diseño inclusivo',
+        body: 'Atajos de teclado, modo oscuro y traducciones aseguran una experiencia universal.',
+      },
+    },
+    editor: {
+      title: 'Editor en línea en vivo',
+      subtitle:
+        'Da formato a documentos, colabora en tiempo real y exporta de inmediato. Todos los cambios se guardan en tu navegador automáticamente.',
+      welcomeTitle: 'Bienvenido al editor de GoTools Lab',
+      welcomeBody:
+        'Usa la barra de herramientas para dar estilo al texto, cargar plantillas o exportar tu documento sin instalar programas.',
+      templatesTitle: 'Plantillas rápidas',
+      templates: {
+        meeting: 'Notas de reunión',
+        content: 'Brief de contenido',
+        todo: 'Plan de acción',
+      },
+      status: 'Cambios guardados localmente',
+      toolbar: {
+        bold: 'Negrita',
+        italic: 'Cursiva',
+        underline: 'Subrayado',
+        bullet: 'Viñetas',
+        numbered: 'Lista numerada',
+        clear: 'Limpiar formato',
+        download: 'Descargar TXT',
+        copy: 'Copiar al portapapeles',
+        theme: 'Cambiar tema',
+      },
+    },
+    global: {
+      title: 'Creado para un público global',
+      subtitle:
+        'Colaboramos con equipos de más de 120 países. Cambia de idioma con un clic y conserva el mismo diseño intuitivo.',
+      localization: {
+        title: 'Localización adaptable',
+        body: 'Textos, ayudas y mensajes siguen tu idioma preferido.',
+      },
+      support: {
+        title: 'Soporte 24/7',
+        body: 'Centros de ayuda en Asia, Europa y América para cubrir todos los husos horarios.',
+      },
+      integrations: {
+        title: 'Integraciones de equipo',
+        body: 'Conecta con Google Drive, Dropbox y Slack para compartir al instante.',
+      },
+    },
+    footer: {
+      tagline: 'Tu laboratorio creativo diario en la nube.',
+      privacy: 'Privacidad',
+      terms: 'Términos',
+      contact: 'Contacto',
+      copyright: '© 2024 GoTools Lab. Todos los derechos reservados.',
+    },
+    editorTemplates: {
+      meeting:
+        '# Notas de reunión\n\n**Fecha:**\n**Asistentes:**\n\n## Agenda\n- \n- \n\n## Decisiones\n- \n\n## Tareas\n- Responsable – Fecha límite',
+      content:
+        '# Brief de contenido\n\n**Campaña:**\n**Audiencia:**\n\n## Mensaje clave\n\n## Formato\n- Artículo\n- Video\n- Social\n\n## Distribución\n- Sitio web\n- Email\n- Anuncios',
+      todo: '# Plan de acción\n\n1. \n2. \n3. \n\n**Próxima revisión:**',
+    },
+    notifications: {
+      copied: 'Copiado al portapapeles',
+      saved: 'Borrador guardado',
+      downloaded: 'Archivo descargado',
+    },
+  },
+};
+
+const languageSelect = document.getElementById('language');
+const searchInput = document.getElementById('search-input');
+const editorCanvas = document.getElementById('editor-canvas');
+const body = document.body;
+
+const SUPPORTED_LANGS = Object.keys(translations);
+const STORAGE_KEYS = {
+  language: 'gotools-language',
+  draft: 'gotools-editor-draft',
+  theme: 'gotools-theme',
+};
+let lastSaveToast = 0;
+
+function safeGet(key) {
+  try {
+    return localStorage.getItem(key);
+  } catch (error) {
+    console.warn('Storage unavailable', error);
+    return null;
+  }
+}
+
+function safeSet(key, value) {
+  try {
+    localStorage.setItem(key, value);
+  } catch (error) {
+    console.warn('Storage unavailable', error);
+  }
+}
+
+function getNestedTranslation(obj, path) {
+  return path.split('.').reduce((acc, key) => (acc ? acc[key] : undefined), obj);
+}
+
+function applyTranslations(lang) {
+  const bundle = translations[lang] || translations.en;
+
+  document.documentElement.lang = lang;
+  document.querySelectorAll('[data-i18n]').forEach((node) => {
+    const key = node.getAttribute('data-i18n');
+    const translation = getNestedTranslation(bundle, key);
+    if (translation) {
+      node.textContent = translation;
+    }
+  });
+
+  document.querySelectorAll('[data-i18n-placeholder]').forEach((node) => {
+    const key = node.getAttribute('data-i18n-placeholder');
+    const translation = getNestedTranslation(bundle, key);
+    if (translation && 'placeholder' in node) {
+      node.placeholder = translation;
+    }
+  });
+
+  document.querySelectorAll('[data-i18n-title]').forEach((node) => {
+    const key = node.getAttribute('data-i18n-title');
+    const translation = getNestedTranslation(bundle, key);
+    if (translation) {
+      node.title = translation;
+      node.setAttribute('aria-label', translation);
+    }
+  });
+
+  // Update static values that are not purely text nodes
+  const statusText = getNestedTranslation(bundle, 'editor.status');
+  if (statusText) {
+    const statusNode = document.querySelector('.editor-status p');
+    if (statusNode) statusNode.textContent = statusText;
+  }
+
+  // Save chosen language
+  safeSet(STORAGE_KEYS.language, lang);
+
+  if (!safeGet(STORAGE_KEYS.draft)) {
+    setEditorWelcome(lang);
+  }
+}
+
+function applyTheme(mode) {
+  if (mode === 'dark') {
+    body.classList.add('dark');
+  } else {
+    body.classList.remove('dark');
+  }
+  safeSet(STORAGE_KEYS.theme, mode);
+}
+
+function initTheme() {
+  const stored = safeGet(STORAGE_KEYS.theme);
+  if (stored === 'dark' || stored === 'light') {
+    applyTheme(stored);
+    return;
+  }
+  const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+  applyTheme(prefersDark ? 'dark' : 'light');
+}
+
+function detectLanguage() {
+  const stored = safeGet(STORAGE_KEYS.language);
+  if (stored && SUPPORTED_LANGS.includes(stored)) {
+    return stored;
+  }
+  const navigatorLang = navigator.language?.slice(0, 2);
+  return SUPPORTED_LANGS.includes(navigatorLang) ? navigatorLang : 'en';
+}
+
+function initLanguage() {
+  const lang = detectLanguage();
+  languageSelect.value = lang;
+  applyTranslations(lang);
+}
+
+languageSelect.addEventListener('change', (event) => {
+  applyTranslations(event.target.value);
+});
+
+function filterTools(value) {
+  const cards = document.querySelectorAll('.tool-card');
+  const query = value.toLowerCase();
+  cards.forEach((card) => {
+    const keywords = card.dataset.keywords || '';
+    const text = card.textContent.toLowerCase();
+    const match = keywords.toLowerCase().includes(query) || text.includes(query);
+    card.classList.toggle('is-hidden', !match);
+  });
+}
+
+searchInput.addEventListener('input', (event) => {
+  filterTools(event.target.value);
+});
+
+function applyTemplate(templateKey) {
+  const currentLang = languageSelect.value;
+  const template = translations[currentLang]?.editorTemplates?.[templateKey];
+  if (template) {
+    editorCanvas.innerText = template;
+    saveDraft();
+  }
+}
+
+function setEditorWelcome(lang) {
+  if (!editorCanvas) return;
+  const bundle = translations[lang] || translations.en;
+  const title = bundle.editor?.welcomeTitle || '';
+  const body = bundle.editor?.welcomeBody || '';
+  editorCanvas.innerHTML = `<h2>${title}</h2><p>${body}</p>`;
+}
+
+function saveDraft(options = {}) {
+  if (!editorCanvas) return;
+  const { silent = false } = options;
+  safeSet(STORAGE_KEYS.draft, editorCanvas.innerHTML);
+  const now = Date.now();
+  if (!silent && now - lastSaveToast > 5000) {
+    showToast('notifications.saved');
+    lastSaveToast = now;
+  }
+}
+
+function restoreDraft() {
+  if (!editorCanvas) return;
+  const saved = safeGet(STORAGE_KEYS.draft);
+  if (saved) {
+    editorCanvas.innerHTML = saved;
+  } else {
+    setEditorWelcome(languageSelect.value);
+  }
+}
+
+function showToast(key) {
+  const toast = document.createElement('div');
+  toast.className = 'toast';
+  const message = getNestedTranslation(translations[languageSelect.value] || translations.en, key);
+  toast.textContent = message || key;
+  document.body.appendChild(toast);
+  requestAnimationFrame(() => toast.classList.add('is-visible'));
+  setTimeout(() => {
+    toast.classList.remove('is-visible');
+    toast.addEventListener('transitionend', () => toast.remove(), { once: true });
+  }, 1800);
+}
+
+function setupEditor() {
+  document.querySelectorAll('[data-command]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const command = button.getAttribute('data-command');
+      document.execCommand(command, false, null);
+      saveDraft({ silent: true });
+    });
+  });
+
+  document.querySelectorAll('[data-template]').forEach((button) => {
+    button.addEventListener('click', () => {
+      applyTemplate(button.dataset.template);
+    });
+  });
+
+  document.querySelectorAll('[data-action]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const action = button.dataset.action;
+      if (action === 'download') {
+        const blob = new Blob([editorCanvas.innerText], { type: 'text/plain;charset=utf-8' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = 'gotools-document.txt';
+        link.click();
+        URL.revokeObjectURL(url);
+        showToast('notifications.downloaded');
+      }
+
+      if (action === 'copy') {
+        if (navigator.clipboard?.writeText) {
+          navigator.clipboard
+            .writeText(editorCanvas.innerText)
+            .then(() => showToast('notifications.copied'))
+            .catch(() => showToast('notifications.copied'));
+        } else {
+          const helper = document.createElement('textarea');
+          helper.value = editorCanvas.innerText;
+          helper.setAttribute('readonly', '');
+          helper.style.position = 'fixed';
+          helper.style.opacity = '0';
+          document.body.appendChild(helper);
+          helper.select();
+          try {
+            document.execCommand('copy');
+            showToast('notifications.copied');
+          } finally {
+            helper.remove();
+          }
+        }
+      }
+
+      if (action === 'darkmode') {
+        const next = body.classList.contains('dark') ? 'light' : 'dark';
+        applyTheme(next);
+      }
+    });
+  });
+
+  editorCanvas.addEventListener('input', () => {
+    saveDraft({ silent: true });
+  });
+}
+
+function enhanceAccessibility() {
+  document.querySelectorAll('a, button').forEach((el) => {
+    el.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' && el.tagName === 'BUTTON') {
+        el.click();
+      }
+    });
+  });
+}
+
+function init() {
+  initTheme();
+  initLanguage();
+  restoreDraft();
+  setupEditor();
+  enhanceAccessibility();
+
+  // initial filter state (clear hidden classes)
+  filterTools('');
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,309 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="GoTools Lab delivers lightweight audio, video, document, and productivity tools with live editing and instant language switching."
+    />
+    <title>GoTools Lab | Online Tool Suite</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/main.css" />
+  </head>
+  <body>
+    <header class="top-bar">
+      <div class="logo" data-i18n="branding.title">GoTools Lab</div>
+      <nav class="main-nav">
+        <a href="#all-tools" data-i18n="navigation.allTools">All tools</a>
+        <a href="#categories" data-i18n="navigation.categories">Categories</a>
+        <a href="#editor" data-i18n="navigation.editor">Online editor</a>
+        <a href="#support" data-i18n="navigation.support">Support</a>
+      </nav>
+      <div class="actions">
+        <div class="language-switch">
+          <label for="language" data-i18n="navigation.languageLabel">Language</label>
+          <select id="language" aria-label="Language switcher">
+            <option value="en">English</option>
+            <option value="zh">简体中文</option>
+            <option value="es">Español</option>
+          </select>
+        </div>
+        <button class="cta" data-i18n="navigation.cta">Start now</button>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero" id="all-tools">
+        <div class="hero-content">
+          <p class="hero-kicker" data-i18n="hero.kicker">One toolkit for every creator</p>
+          <h1 data-i18n="hero.title">
+            Powerful online tools with crystal-clear categories
+          </h1>
+          <p class="hero-subtitle" data-i18n="hero.subtitle">
+            Tackle media, documents, and everyday tasks in seconds. Switch the entire
+            experience to your preferred language and stay productive anywhere.
+          </p>
+          <div class="hero-actions">
+            <a class="primary" href="#editor" data-i18n="hero.primary">Try the online editor</a>
+            <a class="secondary" href="#categories" data-i18n="hero.secondary">Explore categories</a>
+          </div>
+        </div>
+        <div class="hero-showcase">
+          <div class="showcase-card">
+            <h3 data-i18n="showcase.media.title">Media conversion</h3>
+            <p data-i18n="showcase.media.body">
+              Compress, convert, and trim audio or video files right in your browser.
+            </p>
+          </div>
+          <div class="showcase-card">
+            <h3 data-i18n="showcase.documents.title">Smart documents</h3>
+            <p data-i18n="showcase.documents.body">
+              Merge, sign, or transform PDFs without uploading sensitive data.
+            </p>
+          </div>
+          <div class="showcase-card">
+            <h3 data-i18n="showcase.utilities.title">Quick utilities</h3>
+            <p data-i18n="showcase.utilities.body">
+              From screen recorders to GIF makers, launch a tool in one click.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="search" aria-label="tool search">
+        <div class="search-inner">
+          <label for="search-input" class="visually-hidden" data-i18n="search.label">
+            Search tools
+          </label>
+          <input
+            id="search-input"
+            type="search"
+            data-i18n-placeholder="search.placeholder"
+            placeholder="Search for a tool..."
+          />
+          <p class="search-meta" data-i18n="search.meta">48 tools & growing — filter by typing</p>
+        </div>
+      </section>
+
+      <section id="categories" class="categories">
+        <header class="section-header">
+          <h2 data-i18n="categories.title">Curated categories</h2>
+          <p data-i18n="categories.subtitle">
+            Jump straight into the toolkit you need. Every category bundles focused tools with
+            consistent interfaces.
+          </p>
+        </header>
+        <div class="category-grid">
+          <article class="category-card" data-category="audio">
+            <div class="category-icon">🎧</div>
+            <h3 data-i18n="category.audio.title">Audio studio</h3>
+            <p data-i18n="category.audio.description">
+              Trim, mix, and convert audio formats without leaving your browser.
+            </p>
+            <div class="tool-list">
+              <a class="tool-card" data-keywords="audio trim cut mp3" href="#editor">
+                <h4 data-i18n="tool.audioTrimmer.title">Audio trimmer</h4>
+                <p data-i18n="tool.audioTrimmer.description">Cut MP3 or WAV clips precisely online.</p>
+              </a>
+              <a class="tool-card" data-keywords="audio convert format" href="#">
+                <h4 data-i18n="tool.audioConverter.title">Audio converter</h4>
+                <p data-i18n="tool.audioConverter.description">
+                  Switch between MP3, WAV, FLAC, and more instantly.
+                </p>
+              </a>
+              <a class="tool-card" data-keywords="noise remove enhance" href="#">
+                <h4 data-i18n="tool.noiseReducer.title">Noise reducer</h4>
+                <p data-i18n="tool.noiseReducer.description">
+                  Clean background noise with AI-powered smoothing.
+                </p>
+              </a>
+            </div>
+          </article>
+
+          <article class="category-card" data-category="video">
+            <div class="category-icon">🎬</div>
+            <h3 data-i18n="category.video.title">Video lab</h3>
+            <p data-i18n="category.video.description">
+              Edit, resize, and compress videos with lightning-fast previews.
+            </p>
+            <div class="tool-list">
+              <a class="tool-card" data-keywords="video editor cut" href="#">
+                <h4 data-i18n="tool.videoCutter.title">Video cutter</h4>
+                <p data-i18n="tool.videoCutter.description">Split videos into scenes in seconds.</p>
+              </a>
+              <a class="tool-card" data-keywords="video compress" href="#">
+                <h4 data-i18n="tool.videoCompressor.title">Video compressor</h4>
+                <p data-i18n="tool.videoCompressor.description">Reduce file sizes without losing HD clarity.</p>
+              </a>
+              <a class="tool-card" data-keywords="subtitles captions" href="#">
+                <h4 data-i18n="tool.subtitleMaker.title">Subtitle maker</h4>
+                <p data-i18n="tool.subtitleMaker.description">Generate subtitles with live translations.</p>
+              </a>
+            </div>
+          </article>
+
+          <article class="category-card" data-category="document">
+            <div class="category-icon">📄</div>
+            <h3 data-i18n="category.document.title">Document hub</h3>
+            <p data-i18n="category.document.description">
+              Securely transform PDFs, Office files, and scans across formats.
+            </p>
+            <div class="tool-list">
+              <a class="tool-card" data-keywords="pdf merge" href="#">
+                <h4 data-i18n="tool.pdfMerge.title">PDF merger</h4>
+                <p data-i18n="tool.pdfMerge.description">Combine multiple PDFs into a single file.</p>
+              </a>
+              <a class="tool-card" data-keywords="pdf sign" href="#">
+                <h4 data-i18n="tool.pdfSigner.title">PDF signer</h4>
+                <p data-i18n="tool.pdfSigner.description">Add signatures with legally binding timestamps.</p>
+              </a>
+              <a class="tool-card" data-keywords="ocr scan" href="#">
+                <h4 data-i18n="tool.ocrReader.title">OCR reader</h4>
+                <p data-i18n="tool.ocrReader.description">Extract text from scans in 120+ languages.</p>
+              </a>
+            </div>
+          </article>
+
+          <article class="category-card" data-category="utility">
+            <div class="category-icon">🛠️</div>
+            <h3 data-i18n="category.utility.title">Everyday utilities</h3>
+            <p data-i18n="category.utility.description">
+              Lightweight helpers for screenshots, archives, and productivity.
+            </p>
+            <div class="tool-list">
+              <a class="tool-card" data-keywords="screenshot record" href="#">
+                <h4 data-i18n="tool.screenRecorder.title">Screen recorder</h4>
+                <p data-i18n="tool.screenRecorder.description">Capture your screen with microphone audio.</p>
+              </a>
+              <a class="tool-card" data-keywords="gif maker" href="#">
+                <h4 data-i18n="tool.gifMaker.title">GIF maker</h4>
+                <p data-i18n="tool.gifMaker.description">Create looping GIFs from any video clip.</p>
+              </a>
+              <a class="tool-card" data-keywords="archive zip" href="#">
+                <h4 data-i18n="tool.archiveManager.title">Archive manager</h4>
+                <p data-i18n="tool.archiveManager.description">
+                  Zip and unzip archives with drag-and-drop convenience.
+                </p>
+              </a>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="highlights">
+        <div class="highlight-card">
+          <h3 data-i18n="highlights.privacy.title">Privacy-first workflow</h3>
+          <p data-i18n="highlights.privacy.body">
+            Your files stay in your browser. Processing happens locally whenever possible for
+            maximum security.
+          </p>
+        </div>
+        <div class="highlight-card">
+          <h3 data-i18n="highlights.speed.title">Optimised for speed</h3>
+          <p data-i18n="highlights.speed.body">
+            Global CDNs and GPU acceleration mean every tool is ready instantly no matter where
+            you are.
+          </p>
+        </div>
+        <div class="highlight-card">
+          <h3 data-i18n="highlights.accessibility.title">Inclusive design</h3>
+          <p data-i18n="highlights.accessibility.body">
+            Keyboard shortcuts, dark theme, and localisation support create a universal
+            experience.
+          </p>
+        </div>
+      </section>
+
+      <section id="editor" class="editor">
+        <header class="section-header">
+          <h2 data-i18n="editor.title">Live online editor</h2>
+          <p data-i18n="editor.subtitle">
+            Format documents, collaborate in real time, and export text instantly. All changes
+            happen in your browser with auto-save support.
+          </p>
+        </header>
+        <div class="editor-panel">
+          <aside class="editor-sidebar">
+            <h3 data-i18n="editor.templatesTitle">Quick templates</h3>
+            <ul>
+              <li><button data-template="meeting" data-i18n="editor.templates.meeting">Meeting notes</button></li>
+              <li><button data-template="content" data-i18n="editor.templates.content">Content brief</button></li>
+              <li><button data-template="todo" data-i18n="editor.templates.todo">Action plan</button></li>
+            </ul>
+            <div class="editor-status">
+              <span class="status-dot" aria-hidden="true"></span>
+              <p data-i18n="editor.status">Changes saved locally</p>
+            </div>
+          </aside>
+          <div class="editor-main">
+            <div class="editor-toolbar" role="toolbar">
+              <button data-command="bold" aria-label="Bold" data-i18n-title="editor.toolbar.bold">B</button>
+              <button data-command="italic" aria-label="Italic" data-i18n-title="editor.toolbar.italic">I</button>
+              <button data-command="underline" aria-label="Underline" data-i18n-title="editor.toolbar.underline">U</button>
+              <button data-command="insertUnorderedList" aria-label="Bulleted list" data-i18n-title="editor.toolbar.bullet">•</button>
+              <button data-command="insertOrderedList" aria-label="Numbered list" data-i18n-title="editor.toolbar.numbered">1.</button>
+              <button data-command="removeFormat" aria-label="Clear formatting" data-i18n-title="editor.toolbar.clear">⌫</button>
+              <button class="toolbar-button" data-action="download" data-i18n-title="editor.toolbar.download">⬇</button>
+              <button class="toolbar-button" data-action="copy" data-i18n-title="editor.toolbar.copy">⧉</button>
+              <button class="toolbar-button" data-action="darkmode" data-i18n-title="editor.toolbar.theme">☾</button>
+            </div>
+            <div id="editor-canvas" class="editor-canvas" contenteditable="true" role="textbox" aria-multiline="true">
+              <!-- Content is injected by JavaScript to match the selected language. -->
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="global-reach" id="support">
+        <header class="section-header">
+          <h2 data-i18n="global.title">Made for a global audience</h2>
+          <p data-i18n="global.subtitle">
+            We partner with creators and teams from 120+ countries. Switch between languages in
+            one click and keep the same intuitive layout.
+          </p>
+        </header>
+        <div class="reach-grid">
+          <div class="reach-card">
+            <h3 data-i18n="global.localization.title">Adaptive localisation</h3>
+            <p data-i18n="global.localization.body">
+              Interface strings, tooltips, and help guides follow your preferred language.
+            </p>
+          </div>
+          <div class="reach-card">
+            <h3 data-i18n="global.support.title">24/7 support</h3>
+            <p data-i18n="global.support.body">
+              Dedicated help centres in Asia, Europe, and the Americas for true local time zones.
+            </p>
+          </div>
+          <div class="reach-card">
+            <h3 data-i18n="global.integrations.title">Team integrations</h3>
+            <p data-i18n="global.integrations.body">
+              Connect with Google Drive, Dropbox, and Slack to share work instantly.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div>
+        <span class="logo" data-i18n="branding.title">GoTools Lab</span>
+        <p data-i18n="footer.tagline">Your everyday creative lab in the cloud.</p>
+      </div>
+      <div class="footer-links">
+        <a href="#" data-i18n="footer.privacy">Privacy</a>
+        <a href="#" data-i18n="footer.terms">Terms</a>
+        <a href="#" data-i18n="footer.contact">Contact</a>
+      </div>
+      <p class="footer-meta" data-i18n="footer.copyright">© 2024 GoTools Lab. All rights reserved.</p>
+    </footer>
+
+    <script src="assets/js/main.js" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a responsive landing page with hero content, tool categories, global reach messaging, and an inline editor section with language switching
- style the experience with light/dark palettes, card layouts, responsive grids, and toast notifications
- implement localisation data, search filtering, editor templates, auto-save, clipboard/download helpers, and theme persistence in JavaScript
- document the project structure, localisation guidance, and local hosting instructions in the README

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68cc0ea629788322b5a4c335d11ed4ca